### PR TITLE
Convention to support more file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "vscode": "^1.5.0"
     },
     "categories": [
-        "Languages"
+        "Programming Languages"
     ],
     "icon": "res/scriban_128.png",
     "contributes": {
@@ -41,8 +41,23 @@
             },
             {
                 "id": "scriban-html",
-                "aliases": ["Scriban Html", "scriban-html"],
-                "extensions": [".scriban-html", ".scriban-htm", ".sbn-html", ".sbn-htm", ".sbnhtml", ".sbnhtm"],
+                "aliases": ["Scriban Html"],
+                "extensions": [
+                        ".scriban-html", 
+                        ".scriban-htm", 
+                        ".sbn-html", 
+                        ".sbn-htm", 
+                        ".sbnhtml", 
+                        ".sbnhtm",
+                        ".html.scriban",
+                        ".html.sbn"
+                    ],
+                "configuration": "./language-configuration.json"
+            },
+            {
+                "id": "scriban-csharp",
+                "aliases": ["Scriban CSharp"],
+                "extensions": [".cs.scriban", ".cs.sbn"],
                 "configuration": "./language-configuration.json"
             }
         ],
@@ -63,6 +78,15 @@
                 "path": "./syntaxes/scriban-html.tmLanguage",
                 "embeddedLanguages": {
                     "text.html": "html",
+                    "source.scriban": "scriban"
+                }            
+            },
+            {
+                "language": "scriban-csharp",
+                "scopeName": "source.cs.scriban",
+                "path": "./syntaxes/scriban-csharp.tmLanguage",
+                "embeddedLanguages": {
+                    "source.cs": "C#",
                     "source.scriban": "scriban"
                 }            
             }

--- a/syntaxes/scriban-csharp.YAML-tmLanguage
+++ b/syntaxes/scriban-csharp.YAML-tmLanguage
@@ -1,0 +1,15 @@
+name: Scriban-CSharp
+scopeName: source.cs.scriban
+fileTypes: [scriban-csharp]
+uuid: ADF7C6B9-65A4-4461-9A84-8C12AD20A84A
+
+patterns:
+- name: comment.block.scriban
+  begin: '{(%+){'
+  end: '}\1}'
+- name: language.script.scriban
+  begin: '{{~?'
+  end: '~?}}'
+  patterns:
+  - include: source.scriban
+- include: source.cs

--- a/syntaxes/scriban-csharp.tmLanguage
+++ b/syntaxes/scriban-csharp.tmLanguage
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>name</key>
+    <string>Scriban-CSharp</string>
+    <key>scopeName</key>
+    <string>source.cs.scriban</string>
+    <key>fileTypes</key>
+    <array>
+      <string>scriban-csharp</string>
+    </array>
+    <key>uuid</key>
+    <string>ADF7C6B9-65A4-4461-9A84-8C12AD20A84A</string>
+    <key>patterns</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>comment.block.scriban</string>
+        <key>begin</key>
+        <string>{(%+){</string>
+        <key>end</key>
+        <string>}\1}</string>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>language.script.scriban</string>
+        <key>begin</key>
+        <string>{{~?</string>
+        <key>end</key>
+        <string>~?}}</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>source.scriban</string>
+          </dict>
+        </array>
+      </dict>
+      <dict>
+        <key>include</key>
+        <string>source.cs</string>
+      </dict>
+    </array>
+  </dict>
+</plist>


### PR DESCRIPTION
- Add .html.sbn extension; Add .cs.sbn with csharp support.

Please note that I'm not sure if this is the right way. I just played with it and tested once locally. Perhaps there is a simpler and better way to support more extensions. 